### PR TITLE
Add sample PDF with missing table cells and update README for product name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,41 @@
 [Azure Content Understanding in Foundry Tools](https://learn.microsoft.com/en-us/azure/ai-services/content-understanding/) is a solution that analyzes and comprehends various media content—including documents, images, audio, and video—and transforms it into structured, organized, and searchable data. This repository contains assests utilized in the following repository:
 
 - [Azure AI Content Undersanding Samples](https://github.com/Azure-Samples/azure-ai-content-understanding-python)
-    
 
+## Assets
 
+### Audio
+
+| File | Description |
+|------|-------------|
+| `audio/audio.wav` | Simulated Woodgrove Travel customer service call about a Contoso Airways flight delay and partial refund resolution (1 min 54 sec) |
+| `audio/callCenterRecording.mp3` | Simulated call center conversation recording (32 sec) |
+
+### Document
+
+| File | Description |
+|------|-------------|
+| `document/invoice.pdf` | Single-page Contoso invoice with line items, billing/shipping addresses, and payment details |
+| `document/receipt.png` | Contoso retail receipt image with itemized purchases (Surface Pro 6, Surface Pen) |
+| `document/mixed_financial_docs.pdf` | Multi-page PDF (4 pages) combining an invoice, bank statement with transaction history, and a loan application form |
+| `document/mixed_financial_invoices.pdf` | Multi-page PDF (10 pages) with multiple fictional invoices, procurement guidelines, meeting notes, and a product catalog from various vendors |
+| `document/financial_table_with_empty_cells.pdf` | Single-page financial report table with intentionally missing/empty cell values for testing table extraction |
+| `document/financial_table_and_chart.pdf` | Two-page PDF with a financial table containing empty values (page 1) and a quarterly revenue bar chart (page 2) |
+
+### Image
+
+| File | Description |
+|------|-------------|
+| `image/pieChart.jpg` | 3D pie chart showing weekly working hours distribution (1–39h, 40–50h, 50–60h, 60+h) |
+
+### Videos
+
+| File | Description |
+|------|-------------|
+| `videos/highlights/Unlocking AI Innovation.mp4` | AI innovation highlight video (16 min 16 sec) |
+| `videos/learning/learning1.mp4` | Learning module video 1 (1 min 26 sec) |
+| `videos/learning/learning2.mp4` | Learning module video 2 (1 min 1 sec) |
+| `videos/learning/learning3.mp4` | Learning module video 3 (5 min 51 sec) |
+| `videos/learning/learning4.mp4` | Learning module video 4 (47 sec) |
+| `videos/learning/learning5.mp4` | Learning module video 5 (18 sec) |
+| `videos/sdk_samples/FlightSimulator.mp4` | Flight simulator demo video for SDK sample scenarios (43 sec) |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Media Assets for Content Understanding
+# Media Assets for Azure Content Understanding in Foundry Tools
 
-Content Understanding is a solution that analyzes and comprehends various media content—including documents, images, audio, and video—and transforms it into structured, organized, and searchable data. This repository contains assests utilized in the following repository:
+[Azure Content Understanding in Foundry Tools](https://learn.microsoft.com/en-us/azure/ai-services/content-understanding/) is a solution that analyzes and comprehends various media content—including documents, images, audio, and video—and transforms it into structured, organized, and searchable data. This repository contains assests utilized in the following repository:
 
 - [Azure AI Content Undersanding Samples](https://github.com/Azure-Samples/azure-ai-content-understanding-python)
     

--- a/document/financial_table_and_chart.pdf
+++ b/document/financial_table_and_chart.pdf
@@ -1,0 +1,99 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260429211229+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20260429211229+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 2 /Kids [ 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 610
+>>
+stream
+Gatm7?#Q2d'RfGR\.@>Y9O3CtBD/b_br0F&g6>*6>du6>^dcr_rV86mQBDbV<SBkaFKj*%^?7bs1Dd=B]E\.o_T*r'66TV:$"a465N*s&Z8`#NoJe/'kSYa0MU6u8n0"iAZK-UoS?iQ'fZ7)\2Rs3GH8NdA;b2C*qL24T`/#0"BCn;8EMW?1DCU=o`=gb-K`Z$=P\uoOiXoqVr[DA*+I?PqXl<6/b#,C/96C\KjOL+]$U5ZS%qMD[?tD)+a)I*MmO:!E'rpdeEUpd*1MD0a+'?K("W!caKB]i)\qHM&eMk$Me`IKK7#,T(airfs6,anL;SY\/DBUn'Ro@@k2"p]fP2V3[OmaX-^rB4&..kfW1S/iWl+A5QEMH-!1fdS@m/#2A"05=C$?Z;Z++i'tTQ^iJ?5i//l-GBTrQE@Br8\!/X`02-K-k2KIUl@b_9Go26D5<L\#inV4[d#mZ82U.-?"6=e=&(g]*t,f^qN?I^)b`$(biQ4&Mq%INU):9_S8dGd0AC2-cbR,f6m'OY3/=CI%/,Z2-L$/9aB^)`;MZrGDjWQM>)Ml4I;OUX+U*EM-KTT+W!0VeI*"VQga/H*W*$\FJ&k?IfZ_76Tt~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 959
+>>
+stream
+Gas2J92F=s&BF88'Q`I=ODsUWfM8SKjjIIKF/d)h8V9jIO0T-^rUq6rj((N2KUg0.mlq=ECB]n$<;8]E!,d,XGcO(QoT,Y9&G0>gF5I*^K$qJQKUqHZ+cHOo')EVRHogVCDt\\>g\>F:^Q-Y_a8O=Wk^PmJ<G8HX!tEjb8:f;UNA*J3N\BlUD@^Z)H9/^0i8sI6ftrhmN_*k>*"Sq\CpmPm4M2`oq3C![j%35(HZ6'Z-'4CbH$p[kH`:q[m[TL+3h^*meGZ:9\A,QP!@Z@P?WNm.hH3lOafcuV_MYkE/PF]=P?-G.P(M7te?(U@Fi#!@\T8o93@g8PP>m7[_2\Y=0k`UV6F^Ll1P/&ERi#SI:=4lKU#e:%@j_!$47Oo!/8-=;m0h0tY[44=`CALF/:=eeD6G=f8Q\WYg6fgLRY<7AA)ihmpECYM$*C%n!&t''=m"I$On-#6dc<gJ3Ba).%&Jqq.BO8`4Kb?u/?5E^a`%1bnZ*WOX(>bY<lso0&ZrN2[rZn]NFlnd?UipoHP@ck(r<=OjEK7P>mr!Ki];IR>OJfJ-7[#7e&0N\h$U2D>rcS""4C--qg`?VU,-JVMO1`$/-8`S`;sV)Gm-QVF#Dif8gm7njQ$lt%*j'4K@Ije9qAD'.$/41C5!qR/=/<61lroBA-B?LG+p:<(1KHWgMA7Yf2Xf=?&E3O&'HCr?JQK4=kg5Pa>7h]pUEp=iNo0m:!tAJGhQ''bm4t<0lcd<jE.;jQn/>pV<LudndHc[E^$YY:cR@'$)Gl-e0LB%.SaTt=k:#tP3*&_&!\*'4Mjj6M^D<rA=$6'.u#l/Z=uOe8n3^UZHK7YdYX>2N11F-@qfO5`;NTQ;_:hgW\Pt4=9I\#/Gh[Z*[nndi7hZ%#:fbZ^O+SJQH.!P#Fdo@n]jrCSf@-AmJTcW'cV<Ri&Vj-Lpqt`)n<ZXn7?bH\8.c5#K4g[W;~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000448 00000 n 
+0000000642 00000 n 
+0000000836 00000 n 
+0000000904 00000 n 
+0000001200 00000 n 
+0000001265 00000 n 
+0000001966 00000 n 
+trailer
+<<
+/ID 
+[<08eae04016b566d6e59a6d5dfcc05271><08eae04016b566d6e59a6d5dfcc05271>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 12
+>>
+startxref
+3016
+%%EOF

--- a/document/financial_table_with_empty_cells.pdf
+++ b/document/financial_table_with_empty_cells.pdf
@@ -1,0 +1,92 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R /F5 6 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/PageMode /UseNone /Pages 10 0 R /Type /Catalog
+>>
+endobj
+9 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260429174339+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20260429174339+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+10 0 obj
+<<
+/Count 1 /Kids [ 7 0 R ] /Type /Pages
+>>
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 487
+>>
+stream
+GasJO9lIm&%#46K$6Q,OFsoqNPd9<PB[]/PYo^Gd-&cYW=u??#^L*G<N$2A(.B9HsIUCha#%Tsbc8Z!;MdSN^J-eUo^so+j4i&u?\MsVAauDD=i]7+80_.Se;WuH&i[U6VJ[rk._SDoGL@%tR/-Z34^*(!IUpO%P8bjDfT+k9shg(Y<!g_V\/I_!A=[O[HQKf-l4P9uLX/pi9(Z3DPV]a:7<YS_L$B3?O@c")mIn;^-LsqrOS/3Leb5>&_TEM"l3u;+p2T"$molsYX_u#Z=putR,Pd^"l0$s)`i3gX,d[\:31O?;O^M.=)F@S2GL'^0e2:PUX#!(Qu7,+B_'b25TCo8Z'=`l^)d?(c6@q/]eid0$j^4CkG?Yi^7r-mL?W+#V,:,Pj`43LAV&FOSWOCK?+e'Trg]?)9N4?IhCWlD__7bkj;c-7;Oc=?bDUtq0@!5h%fL.Se;0fS3TYqOrd&5SJfafZZQ'(gVRjSK%X~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000144 00000 n 
+0000000251 00000 n 
+0000000363 00000 n 
+0000000473 00000 n 
+0000000578 00000 n 
+0000000693 00000 n 
+0000000888 00000 n 
+0000000957 00000 n 
+0000001253 00000 n 
+0000001313 00000 n 
+trailer
+<<
+/ID 
+[<96de8653b16b9eabc286ba1bf68bb871><96de8653b16b9eabc286ba1bf68bb871>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 9 0 R
+/Root 8 0 R
+/Size 12
+>>
+startxref
+1891
+%%EOF


### PR DESCRIPTION
## Changes

- Add a sample PDF (`document/financial_table_with_empty_cells.pdf`) containing a financial table with missing/empty cell values for testing table extraction.
- Add a sample PDF (`document/financial_table_and_chart.pdf`) with a financial table containing empty values (page 1) and a quarterly revenue bar chart (page 2).
- Update README.md to use the official product name "Azure Content Understanding in Foundry Tools" and add a reference to the [official documentation](https://learn.microsoft.com/en-us/azure/ai-services/content-understanding/).
- Update README.md with a full asset inventory listing all files in audio/, document/, image/, and videos/ directories with descriptions and durations for media files.