### PR TITLE
Re-encode table in financial_table_and_chart.pdf as positioned text objects

### DIFF
--- a/document/financial_table_and_chart.pdf
+++ b/document/financial_table_and_chart.pdf
@@ -1,99 +1,152 @@
 %PDF-1.3
-%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+%âãÏÓ
 1 0 obj
 <<
-/F1 2 0 R /F2 3 0 R /F3 4 0 R
+/Producer (pypdf)
 >>
 endobj
 2 0 obj
 <<
-/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+/Type /Pages
+/Count 2
+/Kids [ 4 0 R 9 0 R ]
 >>
 endobj
 3 0 obj
 <<
-/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+/Type /Catalog
+/Pages 2 0 R
 >>
 endobj
 4 0 obj
 <<
-/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+/Contents 5 0 R
+/MediaBox [ 0 0 612 792 ]
+/Resources <<
+/Font 6 0 R
+/ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>>
+/Rotate 0
+/Trans <<
+>>
+/Type /Page
+/Parent 2 0 R
 >>
 endobj
 5 0 obj
 <<
-/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/Filter [ /ASCII85Decode /FlateDecode ]
+/Length 644
 >>
+stream
+Gat$u9omaW'YNn<GR$K>"=84TRW&@O$ODi[DN;DT'6dr*lmR%HrV>*&drnAn#rV+d):,s@o3N"3k(ENfU'CC__hS[&KH]4TMO"k85N"0/l-D)WUd*1kpjA)A`<r(^J@pWUL']%27Q>3u,?kVh`NKPdJ<SgV/`aYiIsW@s@]1X`B1S5&+FPAT_^XBE2mAW#PdH`Cl'?!0StIFtT2Kh6$7V"B<D3`r"VmhE;S</Z$@XB4nDd1;;'n.U7`rm?ctW^p[*Y+*1X2nf^Cr!X4.edeBDnE@p*=;XRQR$R4/OO,R8UK7,N/kL>81>J'brHolNoOrUg*p4V>1ItM(MJ.GLFDCp77//a`JoX+L%`&TrtBA/t`0h,^,U:'fBE=/j&B;YcK>-.F@e5Bai^($uBgG'U8uCXC+'I,3ZFIP`okne,;[KE5HMWObs5u;u#YTo`1"sS=T1ocOCVH.dr'>3+'16jdp0>4MH>qBk:pTh(;r/Y(P>TR(?jrS]fm#K:s\'4FS;#Rfi=)*QT)e3'6A!@r17?fTi(@;lSSU:\>3dV*<!51ohI)dEnp]oC%cJp0e(nGXg#B\\EpeS$e$mJ^V)8=e^-XK!3r)#)nqrQei"b^@Xl+nl:?un@n!*0o$'B6io;s!TlOq&H~>
+endstream
 endobj
 6 0 obj
 <<
-/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
-/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/F1 7 0 R
+/F2 8 0 R
 >>
 endobj
 7 0 obj
 <<
-/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Name /F1
+/Subtype /Type1
+/Type /Font
 >>
 endobj
 8 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260429211229+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20260429211229+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
-  /Subject (unspecified) /Title (untitled) /Trapped /False
+/BaseFont /Helvetica-Bold
+/Encoding /WinAnsiEncoding
+/Name /F2
+/Subtype /Type1
+/Type /Font
 >>
 endobj
 9 0 obj
 <<
-/Count 2 /Kids [ 5 0 R 6 0 R ] /Type /Pages
+/Contents 10 0 R
+/MediaBox [ 0 0 612 792 ]
+/Resources <<
+/Font 11 0 R
+/ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>>
+/Rotate 0
+/Trans <<
+>>
+/Type /Page
+/Parent 2 0 R
 >>
 endobj
 10 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 610
+/Filter [ /ASCII85Decode /FlateDecode ]
+/Length 959
 >>
 stream
-Gatm7?#Q2d'RfGR\.@>Y9O3CtBD/b_br0F&g6>*6>du6>^dcr_rV86mQBDbV<SBkaFKj*%^?7bs1Dd=B]E\.o_T*r'66TV:$"a465N*s&Z8`#NoJe/'kSYa0MU6u8n0"iAZK-UoS?iQ'fZ7)\2Rs3GH8NdA;b2C*qL24T`/#0"BCn;8EMW?1DCU=o`=gb-K`Z$=P\uoOiXoqVr[DA*+I?PqXl<6/b#,C/96C\KjOL+]$U5ZS%qMD[?tD)+a)I*MmO:!E'rpdeEUpd*1MD0a+'?K("W!caKB]i)\qHM&eMk$Me`IKK7#,T(airfs6,anL;SY\/DBUn'Ro@@k2"p]fP2V3[OmaX-^rB4&..kfW1S/iWl+A5QEMH-!1fdS@m/#2A"05=C$?Z;Z++i'tTQ^iJ?5i//l-GBTrQE@Br8\!/X`02-K-k2KIUl@b_9Go26D5<L\#inV4[d#mZ82U.-?"6=e=&(g]*t,f^qN?I^)b`$(biQ4&Mq%INU):9_S8dGd0AC2-cbR,f6m'OY3/=CI%/,Z2-L$/9aB^)`;MZrGDjWQM>)Ml4I;OUX+U*EM-KTT+W!0VeI*"VQga/H*W*$\FJ&k?IfZ_76Tt~>endstream
+Gas2J92F=s&BF88'Q`I=ODsUWfM8SKjjIIKF/d)h8V9jIO0T-^rUq6rj((N2KUg0.mlq=ECB]n$<;8]E!,d,XGcO(QoT,Y9&G0>gF5I*^K$qJQKUqHZ+cHOo')EVRHogVCDt\\>g\>F:^Q-Y_a8O=Wk^PmJ<G8HX!tEjb8:f;UNA*J3N\BlUD@^Z)H9/^0i8sI6ftrhmN_*k>*"Sq\CpmPm4M2`oq3C![j%35(HZ6'Z-'4CbH$p[kH`:q[m[TL+3h^*meGZ:9\A,QP!@Z@P?WNm.hH3lOafcuV_MYkE/PF]=P?-G.P(M7te?(U@Fi#!@\T8o93@g8PP>m7[_2\Y=0k`UV6F^Ll1P/&ERi#SI:=4lKU#e:%@j_!$47Oo!/8-=;m0h0tY[44=`CALF/:=eeD6G=f8Q\WYg6fgLRY<7AA)ihmpECYM$*C%n!&t''=m"I$On-#6dc<gJ3Ba).%&Jqq.BO8`4Kb?u/?5E^a`%1bnZ*WOX(>bY<lso0&ZrN2[rZn]NFlnd?UipoHP@ck(r<=OjEK7P>mr!Ki];IR>OJfJ-7[#7e&0N\h$U2D>rcS""4C--qg`?VU,-JVMO1`$/-8`S`;sV)Gm-QVF#Dif8gm7njQ$lt%*j'4K@Ije9qAD'.$/41C5!qR/=/<61lroBA-B?LG+p:<(1KHWgMA7Yf2Xf=?&E3O&'HCr?JQK4=kg5Pa>7h]pUEp=iNo0m:!tAJGhQ''bm4t<0lcd<jE.;jQn/>pV<LudndHc[E^$YY:cR@'$)Gl-e0LB%.SaTt=k:#tP3*&_&!\*'4Mjj6M^D<rA=$6'.u#l/Z=uOe8n3^UZHK7YdYX>2N11F-@qfO5`;NTQ;_:hgW\Pt4=9I\#/Gh[Z*[nndi7hZ%#:fbZ^O+SJQH.!P#Fdo@n]jrCSf@-AmJTcW'cV<Ri&Vj-Lpqt`)n<ZXn7?bH\8.c5#K4g[W;~>
+endstream
 endobj
 11 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 959
+/F1 12 0 R
+/F2 13 0 R
+/F3 14 0 R
 >>
-stream
-Gas2J92F=s&BF88'Q`I=ODsUWfM8SKjjIIKF/d)h8V9jIO0T-^rUq6rj((N2KUg0.mlq=ECB]n$<;8]E!,d,XGcO(QoT,Y9&G0>gF5I*^K$qJQKUqHZ+cHOo')EVRHogVCDt\\>g\>F:^Q-Y_a8O=Wk^PmJ<G8HX!tEjb8:f;UNA*J3N\BlUD@^Z)H9/^0i8sI6ftrhmN_*k>*"Sq\CpmPm4M2`oq3C![j%35(HZ6'Z-'4CbH$p[kH`:q[m[TL+3h^*meGZ:9\A,QP!@Z@P?WNm.hH3lOafcuV_MYkE/PF]=P?-G.P(M7te?(U@Fi#!@\T8o93@g8PP>m7[_2\Y=0k`UV6F^Ll1P/&ERi#SI:=4lKU#e:%@j_!$47Oo!/8-=;m0h0tY[44=`CALF/:=eeD6G=f8Q\WYg6fgLRY<7AA)ihmpECYM$*C%n!&t''=m"I$On-#6dc<gJ3Ba).%&Jqq.BO8`4Kb?u/?5E^a`%1bnZ*WOX(>bY<lso0&ZrN2[rZn]NFlnd?UipoHP@ck(r<=OjEK7P>mr!Ki];IR>OJfJ-7[#7e&0N\h$U2D>rcS""4C--qg`?VU,-JVMO1`$/-8`S`;sV)Gm-QVF#Dif8gm7njQ$lt%*j'4K@Ije9qAD'.$/41C5!qR/=/<61lroBA-B?LG+p:<(1KHWgMA7Yf2Xf=?&E3O&'HCr?JQK4=kg5Pa>7h]pUEp=iNo0m:!tAJGhQ''bm4t<0lcd<jE.;jQn/>pV<LudndHc[E^$YY:cR@'$)Gl-e0LB%.SaTt=k:#tP3*&_&!\*'4Mjj6M^D<rA=$6'.u#l/Z=uOe8n3^UZHK7YdYX>2N11F-@qfO5`;NTQ;_:hgW\Pt4=9I\#/Gh[Z*[nndi7hZ%#:fbZ^O+SJQH.!P#Fdo@n]jrCSf@-AmJTcW'cV<Ri&Vj-Lpqt`)n<ZXn7?bH\8.c5#K4g[W;~>endstream
+endobj
+12 0 obj
+<<
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+/Name /F1
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+13 0 obj
+<<
+/BaseFont /Helvetica-Bold
+/Encoding /WinAnsiEncoding
+/Name /F2
+/Subtype /Type1
+/Type /Font
+>>
+endobj
+14 0 obj
+<<
+/BaseFont /Courier
+/Encoding /WinAnsiEncoding
+/Name /F3
+/Subtype /Type1
+/Type /Font
+>>
 endobj
 xref
-0 12
+0 15
 0000000000 65535 f 
-0000000073 00000 n 
-0000000124 00000 n 
-0000000231 00000 n 
-0000000343 00000 n 
-0000000448 00000 n 
-0000000642 00000 n 
-0000000836 00000 n 
-0000000904 00000 n 
-0000001200 00000 n 
-0000001265 00000 n 
-0000001966 00000 n 
+0000000015 00000 n 
+0000000054 00000 n 
+0000000119 00000 n 
+0000000168 00000 n 
+0000000357 00000 n 
+0000001092 00000 n 
+0000001133 00000 n 
+0000001240 00000 n 
+0000001352 00000 n 
+0000001543 00000 n 
+0000002594 00000 n 
+0000002649 00000 n 
+0000002757 00000 n 
+0000002870 00000 n 
 trailer
 <<
-/ID 
-[<08eae04016b566d6e59a6d5dfcc05271><08eae04016b566d6e59a6d5dfcc05271>]
-% ReportLab generated PDF document -- digest (http://www.reportlab.com)
-
-/Info 8 0 R
-/Root 7 0 R
-/Size 12
+/Size 15
+/Root 3 0 R
+/Info 1 0 R
 >>
 startxref
-3016
+2976
 %%EOF


### PR DESCRIPTION
## Summary

Re-encoded the table on page 1 of `financial_table_and_chart.pdf` from a single space-padded text block to individually positioned text objects (each cell is a separate `drawString(x, y, text)` call).

## Why

The previous encoding used a single text block with whitespace padding, which popular LangChain PDF loaders (PyPDFLoader, PyMuPDFLoader) could accidentally parse into readable columns. The new encoding uses positioned text fragments — the same method used by Word, Excel, and LaTeX PDF exports — where standard text extraction produces a flat list of values with no column association.

This makes the file a better test case for demonstrating Content Understanding's advantage over traditional PDF loaders:
- **PyPDFLoader (default)**: Flat text dump — `Marketing\n980\n9\nSupport\n420\n...`
- **PyMuPDFLoader**: Same flat text
- **CU**: Proper markdown table with aligned columns and explicit empty cells

## Changes

- `document/financial_table_and_chart.pdf`: Page 1 re-encoded, page 2 (chart) unchanged
- Table data is identical — same departments, same values, same empty cells
- Visually identical when opened in a PDF viewer